### PR TITLE
AV-249244 Update application profile ut and fix invalid app ref resolved ref updation

### DIFF
--- a/ako-gateway-api/nodes/route_model.go
+++ b/ako-gateway-api/nodes/route_model.go
@@ -330,12 +330,12 @@ func (hr *httpRoute) ParseRouteConfig(key string) *RouteConfig {
 				var isValid bool
 				isValid, resolvedRefConditionRuleFilter = validateFilterExtensionRef(key, hr.GetNamespace(), filter.ExtensionRef)
 				if !isValid {
+					if resolvedRefConditionRuleFilter != nil {
+						resolvedRefCondition = resolvedRefConditionRuleFilter
+					}
 					continue
 				}
 
-			}
-			if resolvedRefConditionRuleFilter != nil {
-				resolvedRefCondition = resolvedRefConditionRuleFilter
 			}
 			routeConfigRule.Filters = append(routeConfigRule.Filters, filter)
 		}


### PR DESCRIPTION
Updates application profile tests and fixes invalid app ref resolved ref updation

```
aviuser@node1:~/workspace/n1lesh/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests$ go test -run "AppProfile" ./.
..
?       github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests       [no test files]
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/crd   0.150s [no tests to run]
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/graphlayer    32.239s
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/ingestion     10.208s
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/multitenancy  0.028s [no tests to run]
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/npltests      0.104s [no tests to run]
ok      github.com/vmware/load-balancer-and-ingress-services-for-kubernetes/tests/gatewayapitests/status        10.198s
```